### PR TITLE
Adds phantomjs timeout to Tasks so it can be configurable

### DIFF
--- a/data/fixture/test/tasks.js
+++ b/data/fixture/test/tasks.js
@@ -23,6 +23,7 @@ module.exports = [
 		_id: new ObjectID('abc000000000000000000001'),
 		name: 'NPG Home',
 		url: 'nature.com',
+		timeout: '30000',
 		standard: 'WCAG2AA',
 		ignore: ['foo', 'bar']
 	},
@@ -30,12 +31,14 @@ module.exports = [
 		_id: new ObjectID('abc000000000000000000002'),
 		name: 'NPG Home',
 		url: 'nature.com',
+		timeout: '30000',
 		standard: 'WCAG2AAA'
 	},
 	{
 		_id: new ObjectID('abc000000000000000000003'),
 		name: 'Nature News',
 		url: 'nature.com/news',
+		timeout: '30000',
 		standard: 'Section508'
 	}
 ];

--- a/data/fixture/test/tasks.js
+++ b/data/fixture/test/tasks.js
@@ -23,7 +23,7 @@ module.exports = [
 		_id: new ObjectID('abc000000000000000000001'),
 		name: 'NPG Home',
 		url: 'nature.com',
-		timeout: '30000',
+		timeout: 30000,
 		standard: 'WCAG2AA',
 		ignore: ['foo', 'bar']
 	},
@@ -31,14 +31,14 @@ module.exports = [
 		_id: new ObjectID('abc000000000000000000002'),
 		name: 'NPG Home',
 		url: 'nature.com',
-		timeout: '30000',
+		timeout: 30000,
 		standard: 'WCAG2AAA'
 	},
 	{
 		_id: new ObjectID('abc000000000000000000003'),
 		name: 'Nature News',
 		url: 'nature.com/news',
-		timeout: '30000',
+		timeout: 30000,
 		standard: 'Section508'
 	}
 ];

--- a/model/task.js
+++ b/model/task.js
@@ -23,7 +23,7 @@ var pa11y = require('pa11y');
 // Task model
 module.exports = function (app, callback) {
 	app.db.collection('tasks', function (err, collection) {
-		collection.ensureIndex({name: 1, url: 1, standard: 1}, {w: -1});
+		collection.ensureIndex({name: 1, url: 1, standard: 1, timeout: 1}, {w: -1});
 		var model = {
 
 			collection: collection,
@@ -79,7 +79,8 @@ module.exports = function (app, callback) {
 				}
 				var now = Date.now();
 				var taskEdits = {
-					name: edits.name
+					name: edits.name,
+					timeout: edits.timeout
 				}
 				if (edits.ignore) {
 					taskEdits.ignore = edits.ignore;
@@ -137,6 +138,7 @@ module.exports = function (app, callback) {
 							pa11y.sniff({
 								url: task.url,
 								standard: task.standard,
+								timeout: task.timeout,
 								config: {
 									ignore: task.ignore
 								},
@@ -163,6 +165,7 @@ module.exports = function (app, callback) {
 					id: task._id.toString(),
 					name: task.name,
 					url: task.url,
+					timeout: task.timeout,
 					standard: task.standard,
 					ignore: task.ignore || []
 				};

--- a/model/task.js
+++ b/model/task.js
@@ -23,7 +23,7 @@ var pa11y = require('pa11y');
 // Task model
 module.exports = function (app, callback) {
 	app.db.collection('tasks', function (err, collection) {
-		collection.ensureIndex({name: 1, url: 1, standard: 1, timeout: 1}, {w: -1});
+		collection.ensureIndex({name: 1, url: 1, standard: 1}, {w: -1});
 		var model = {
 
 			collection: collection,

--- a/route/task.js
+++ b/route/task.js
@@ -100,7 +100,7 @@ module.exports = function (app) {
 					query: {},
 					payload: {
 						name: Hapi.types.String().required(),
-						timeout: Hapi.types.Number().integer().required(),
+						timeout: Hapi.types.Number().integer(),
 						ignore: Hapi.types.Array(),
 						comment: Hapi.types.String()
 					}

--- a/route/task.js
+++ b/route/task.js
@@ -100,6 +100,7 @@ module.exports = function (app) {
 					query: {},
 					payload: {
 						name: Hapi.types.String().required(),
+						timeout: Hapi.types.Number().integer().required(),
 						ignore: Hapi.types.Array(),
 						comment: Hapi.types.String()
 					}

--- a/route/tasks.js
+++ b/route/tasks.js
@@ -83,6 +83,7 @@ module.exports = function (app) {
 					query: {},
 					payload: {
 						name: Hapi.types.String().required(),
+						timeout: Hapi.types.Number().integer().required(),
 						url: Hapi.types.String().required(),
 						standard: Hapi.types.String().required().valid([
 							'Section508', 'WCAG2A', 'WCAG2AA', 'WCAG2AAA'

--- a/test/functional/create-task.js
+++ b/test/functional/create-task.js
@@ -28,6 +28,7 @@ describe('POST /tasks', function () {
 			newTask = {
 				name: 'NPG Home',
 				url: 'nature.com',
+				timeout: '30000',
 				standard: 'WCAG2AA',
 				ignore: ['foo', 'bar']
 			};
@@ -72,6 +73,7 @@ describe('POST /tasks', function () {
 			newTask = {
 				name: 'NPG Home',
 				url: 'nature.com',
+				timeout: '30000',
 				standard: 'WCAG2AA'
 			};
 			var req = {

--- a/test/functional/edit-task-by-id.js
+++ b/test/functional/edit-task-by-id.js
@@ -29,6 +29,7 @@ describe('PATCH /tasks/{id}', function () {
 			beforeEach(function (done) {
 				taskEdits = {
 					name: 'New Name',
+					timeout: '30000',
 					ignore: ['bar', 'baz'],
 					comment: 'Just changing some stuff, you know'
 				};
@@ -131,7 +132,8 @@ describe('PATCH /tasks/{id}', function () {
 				method: 'PATCH',
 				endpoint: 'tasks/abc000000000000000000000',
 				body: {
-					name: 'foo'
+					name: 'foo',
+					timeout: '30000'
 				}
 			};
 			this.navigate(req, done);
@@ -150,7 +152,8 @@ describe('PATCH /tasks/{id}', function () {
 				method: 'PATCH',
 				endpoint: 'tasks/-abc-',
 				body: {
-					name: 'foo'
+					name: 'foo',
+					timeout: '30000'
 				}
 			};
 			this.navigate(req, done);


### PR DESCRIPTION
Adds the ability to specify a timeout per Task. This is possible in the library (https://github.com/nature/pa11y#optionstimeout) but not currently the webservice or dashboard as they don't pass this option to ``pa11y.sniff()``.

I've made changes to the dashboard to allow this too which I'll send a pull request for when this is merged and tagged: https://github.com/Bendihossan/pa11y-dashboard/commit/57afcfaf6120bc7771f0dad55f320b182d6e7fbb

I've only just seen the contributing guidelines on the dashboard repository, otherwise I'd have created an issue for it on issue tracker first, sorry!