### PR TITLE
chore: As pa11y 3.x Node 0.10 is unsupported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 
 # Language/versions
 language: node_js
-node_js:
-  - "0.10"
+matrix:
+  include:
+
+    # Run tests in Node.js 0.10 (unsupported)
+    - node_js: '0.10'
+
+    # Run tests in Node.js 0.12
+    - node_js: '0.12'
+
+    # Run tests in Node.js 4.x
+    - node_js: '4'
+
+  # Allow Node.js 0.10 to fail – it's unsupported
+  allow_failures:
+    - node_js: '0.10'
 
 # Build only master (and pull-requests)
 branches:

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ pa11y-webservice provides scheduled accessibility reports for multiple URLs. It 
 
 **Current Version:** *1.6.3*  
 **Build Status:** [![Build Status][travis-img]][travis]  
-**Node Version Support:** *0.10*
+**Node Version Support:** *0.12*
 
 
 Setup
 -----
 
-pa11y-webservice requires [Node.js][node] 0.10+ and [PhantomJS][phantom]. See the [pa11y documentation][pa11y-docs] for more information on these dependencies. pa11y-webservice also requires [MongoDB][mongo] to be installed and running.
+pa11y-webservice requires [Node.js][node] 0.12+ and [PhantomJS][phantom]. See the [pa11y documentation][pa11y-docs] for more information on these dependencies. pa11y-webservice also requires [MongoDB][mongo] to be installed and running.
 
 You'll then need to clone this repo locally and install dependencies with `npm install`. Once you have a local clone, you'll need to copy some sample configuration files in order to run the application. From within the repo, run the following commands:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "pa11y-webservice",
 	"version": "1.6.3",
+	
+	"engines": {
+		"node": ">=0.12"
+	},
 
 	"description": "pa11y-webservice provides scheduled accessibility reports for multiple URLs",
 	"keywords": [ "accessibility", "analysis", "report", "web-service" ],


### PR DESCRIPTION
As pa11y 3.x is unsupported on Node 0.10 I believe we need to adapt the tests in this repository as well.